### PR TITLE
Include v6 donations in GIVbacks calculation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,7 @@
 GIVETHIO_BASE_URL=https://mainnet.serve.giveth.io
+GIVETH_V6_CORE_API_URL=https://core.giveth.io
+POWER_SYNC_PASSWORD=
+POWER_SYNC_PASSWORD_HEADER=x-power-sync-password
 TRACE_BASE_URL=https://feathers.beta.giveth.io
 PURPLE_LIST=0x1ad91ee08f21be3de0ba2ba6918e714da6b45836,0x63ecc058D97ED7bAb75616B77C96734D0B823f87
 MAINNET_NODE_URL=https://mainnet.infura.io/v3/infuraApiKey

--- a/src/givethIoService.ts
+++ b/src/givethIoService.ts
@@ -130,7 +130,7 @@ const donationDedupeIdentifiers = (donation: FormattedDonation): string[] => {
 
   const txHash = normalizeDedupeValue(donation.txHash)
   const network = normalizeDedupeValue(donation.network)
-  if (txHash || network) {
+  if (txHash && network) {
     identifiers.push(`tx:${network}:${txHash}`)
   }
 
@@ -156,6 +156,24 @@ const mergeAndDedupeDonations = (
       .find(Boolean)
 
     if (existingKey) {
+      const existingDonation = donationsByKey.get(existingKey)
+      const shouldPromoteIncomingDonation =
+        Boolean(donation.parentRecurringDonationId) &&
+        !existingDonation?.parentRecurringDonationId
+
+      if (key && existingDonation && shouldPromoteIncomingDonation) {
+        donationsByKey.delete(existingKey)
+        donationsByKey.set(key, donation)
+        const promotedIdentifiers = [
+          ...donationDedupeIdentifiers(existingDonation),
+          ...identifiers,
+        ]
+        promotedIdentifiers.forEach(identifier =>
+          canonicalKeyByIdentifier.set(identifier, key),
+        )
+        continue
+      }
+
       identifiers.forEach(identifier =>
         canonicalKeyByIdentifier.set(identifier, existingKey),
       )

--- a/src/givethIoService.ts
+++ b/src/givethIoService.ts
@@ -14,6 +14,7 @@ const { isAddress } = require("ethers");
 require('dotenv').config()
 
 const { gql, request } = require('graphql-request');
+const axios = require('axios');
 const moment = require('moment')
 const _ = require('underscore')
 
@@ -30,6 +31,10 @@ import {
 } from "./utils";
 
 const givethiobaseurl = process.env.GIVETHIO_BASE_URL
+const givethV6CoreApiUrl = process.env.GIVETH_V6_CORE_API_URL
+const givethV6CoreApiPassword = process.env.POWER_SYNC_PASSWORD
+const givethV6CoreApiPasswordHeader =
+  process.env.POWER_SYNC_PASSWORD_HEADER || 'x-power-sync-password'
 const xdaiNodeHttpUrl = process.env.XDAI_NODE_HTTP_URL
 const twoWeeksInMilliseconds = 1209600000
 console.log()
@@ -49,6 +54,79 @@ const isStellarDonationAndUserLoggedInWithEvmAddress = (donation: GivethIoDonati
 
 const donationGiverAddress = (donation: GivethIoDonation): string => {
   return isStellarDonationAndUserLoggedInWithEvmAddress(donation) ? donation.user.walletAddress : donation.fromWalletAddress
+}
+
+const getV6EligibleDonations = async (
+  params: {
+    beginDate: string,
+    endDate: string,
+    minEligibleValueUsd: number,
+    givethCommunityProjectSlug: string,
+    niceWhitelistTokens?: string[],
+    niceProjectSlugs?: string[],
+  }): Promise<FormattedDonation[]> => {
+  if (!givethV6CoreApiUrl || !givethV6CoreApiPassword) {
+    console.log('Skipping v6 Core donations: missing GIVETH_V6_CORE_API_URL or POWER_SYNC_PASSWORD')
+    return []
+  }
+
+  const response = await axios.get(
+    `${givethV6CoreApiUrl.replace(/\/$/, '')}/api/internal/givbacks/donations`,
+    {
+      headers: {
+        [givethV6CoreApiPasswordHeader]: givethV6CoreApiPassword,
+      },
+      params: {
+        fromDate: params.beginDate,
+        toDate: params.endDate,
+        minEligibleValueUsd: params.minEligibleValueUsd,
+        givethCommunityProjectSlug: params.givethCommunityProjectSlug,
+        ...(params.niceWhitelistTokens?.length
+          ? { niceWhitelistTokens: params.niceWhitelistTokens.join(',') }
+          : {}),
+        ...(params.niceProjectSlugs?.length
+          ? { niceProjectSlugs: params.niceProjectSlugs.join(',') }
+          : {}),
+      },
+    },
+  )
+
+  const rows = response?.data?.data
+  if (!Array.isArray(rows)) {
+    return []
+  }
+
+  return rows.map((row: FormattedDonation) => ({
+    ...row,
+    giverName: row.giverName || '',
+    giverEmail: row.giverEmail || '',
+    isReferrerGivbackEligible: Boolean(row.isReferrerGivbackEligible),
+    referrerWallet: row.referrerWallet || undefined,
+  }))
+}
+
+const donationDedupeKey = (donation: FormattedDonation): string => {
+  if (donation.parentRecurringDonationId) {
+    return `recurring:${donation.parentRecurringDonationId}`
+  }
+
+  return `tx:${donation.network}:${donation.txHash}`.toLowerCase()
+}
+
+const mergeAndDedupeDonations = (
+  donations: FormattedDonation[],
+  additionalDonations: FormattedDonation[],
+): FormattedDonation[] => {
+  const donationsByKey = new Map<string, FormattedDonation>()
+
+  for (const donation of donations.concat(additionalDonations)) {
+    const key = donationDedupeKey(donation)
+    if (!donationsByKey.has(key)) {
+      donationsByKey.set(key, donation)
+    }
+  }
+
+  return Array.from(donationsByKey.values())
 }
 
 /**
@@ -317,7 +395,20 @@ export const getEligibleDonations = async (
       // It should be zero
       commonDonations: commonDonations.length
     })
-    return eligible ? eligibleDonations : notEligibleDonations
+    if (!eligible) {
+      return notEligibleDonations
+    }
+
+    const v6EligibleDonations = await getV6EligibleDonations({
+      beginDate,
+      endDate,
+      niceWhitelistTokens,
+      niceProjectSlugs,
+      minEligibleValueUsd,
+      givethCommunityProjectSlug,
+    })
+
+    return mergeAndDedupeDonations(eligibleDonations, v6EligibleDonations)
 
 
   } catch (e) {

--- a/src/givethIoService.ts
+++ b/src/givethIoService.ts
@@ -35,6 +35,9 @@ const givethV6CoreApiUrl = process.env.GIVETH_V6_CORE_API_URL
 const givethV6CoreApiPassword = process.env.POWER_SYNC_PASSWORD
 const givethV6CoreApiPasswordHeader =
   process.env.POWER_SYNC_PASSWORD_HEADER || 'x-power-sync-password'
+const givethV6CoreApiTimeoutMs = Number(
+  process.env.GIVETH_V6_CORE_API_TIMEOUT_MS || 15000,
+)
 const xdaiNodeHttpUrl = process.env.XDAI_NODE_HTTP_URL
 const twoWeeksInMilliseconds = 1209600000
 console.log()
@@ -70,26 +73,34 @@ const getV6EligibleDonations = async (
     return []
   }
 
-  const response = await axios.get(
-    `${givethV6CoreApiUrl.replace(/\/$/, '')}/api/internal/givbacks/donations`,
-    {
-      headers: {
-        [givethV6CoreApiPasswordHeader]: givethV6CoreApiPassword,
+  let response
+  try {
+    response = await axios.get(
+      `${givethV6CoreApiUrl.replace(/\/$/, '')}/api/internal/givbacks/donations`,
+      {
+        headers: {
+          [givethV6CoreApiPasswordHeader]: givethV6CoreApiPassword,
+        },
+        params: {
+          fromDate: params.beginDate,
+          toDate: params.endDate,
+          minEligibleValueUsd: params.minEligibleValueUsd,
+          givethCommunityProjectSlug: params.givethCommunityProjectSlug,
+          ...(params.niceWhitelistTokens?.length
+            ? { niceWhitelistTokens: params.niceWhitelistTokens.join(',') }
+            : {}),
+          ...(params.niceProjectSlugs?.length
+            ? { niceProjectSlugs: params.niceProjectSlugs.join(',') }
+            : {}),
+        },
+        timeout: givethV6CoreApiTimeoutMs,
       },
-      params: {
-        fromDate: params.beginDate,
-        toDate: params.endDate,
-        minEligibleValueUsd: params.minEligibleValueUsd,
-        givethCommunityProjectSlug: params.givethCommunityProjectSlug,
-        ...(params.niceWhitelistTokens?.length
-          ? { niceWhitelistTokens: params.niceWhitelistTokens.join(',') }
-          : {}),
-        ...(params.niceProjectSlugs?.length
-          ? { niceProjectSlugs: params.niceProjectSlugs.join(',') }
-          : {}),
-      },
-    },
-  )
+    )
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    console.log('Skipping v6 Core donations: request failed', message)
+    return []
+  }
 
   const rows = response?.data?.data
   if (!Array.isArray(rows)) {
@@ -105,12 +116,29 @@ const getV6EligibleDonations = async (
   }))
 }
 
-const donationDedupeKey = (donation: FormattedDonation): string => {
+const normalizeDedupeValue = (value?: string | number): string => {
+  return String(value || '').trim().toLowerCase()
+}
+
+const donationDedupeIdentifiers = (donation: FormattedDonation): string[] => {
+  const identifiers: string[] = []
   if (donation.parentRecurringDonationId) {
-    return `recurring:${donation.parentRecurringDonationId}`
+    identifiers.push(
+      `recurring:${normalizeDedupeValue(donation.parentRecurringDonationId)}`,
+    )
   }
 
-  return `tx:${donation.network}:${donation.txHash}`.toLowerCase()
+  const txHash = normalizeDedupeValue(donation.txHash)
+  const network = normalizeDedupeValue(donation.network)
+  if (txHash || network) {
+    identifiers.push(`tx:${network}:${txHash}`)
+  }
+
+  return identifiers
+}
+
+const donationDedupeKey = (donation: FormattedDonation): string => {
+  return donationDedupeIdentifiers(donation).join('|')
 }
 
 const mergeAndDedupeDonations = (
@@ -118,11 +146,27 @@ const mergeAndDedupeDonations = (
   additionalDonations: FormattedDonation[],
 ): FormattedDonation[] => {
   const donationsByKey = new Map<string, FormattedDonation>()
+  const canonicalKeyByIdentifier = new Map<string, string>()
 
   for (const donation of donations.concat(additionalDonations)) {
     const key = donationDedupeKey(donation)
-    if (!donationsByKey.has(key)) {
+    const identifiers = donationDedupeIdentifiers(donation)
+    const existingKey = identifiers
+      .map(identifier => canonicalKeyByIdentifier.get(identifier))
+      .find(Boolean)
+
+    if (existingKey) {
+      identifiers.forEach(identifier =>
+        canonicalKeyByIdentifier.set(identifier, existingKey),
+      )
+      continue
+    }
+
+    if (key && !donationsByKey.has(key)) {
       donationsByKey.set(key, donation)
+      identifiers.forEach(identifier =>
+        canonicalKeyByIdentifier.set(identifier, key),
+      )
     }
   }
 
@@ -384,8 +428,14 @@ export const getEligibleDonations = async (
     const notEligibleDonations = (
       await purpleListDonations(formattedDonationsToVerifiedProjects)
     ).concat(formattedDonationsToNotVerifiedProjects)
-    const eligibleTxHashes = new Set(eligibleDonations.map(donation => donation.txHash));
-    const commonDonations = notEligibleDonations.filter(donation => eligibleTxHashes.has(donation.txHash));
+    const eligibleDonationKeys = new Set(
+      eligibleDonations.flatMap(donation => donationDedupeIdentifiers(donation)),
+    )
+    const commonDonations = notEligibleDonations.filter(donation =>
+      donationDedupeIdentifiers(donation).some(key =>
+        eligibleDonationKeys.has(key),
+      ),
+    )
 
 
     console.log('donations length', {


### PR DESCRIPTION
## Issue

Giveth/giveth-v6-core#264

## Summary

Updates the GIVbacks calculation service to fetch eligible v6 donations from Core and merge them with the existing v5 donation set. This makes `/calculate` include both sources while avoiding duplicate rows when the same transaction or recurring stream appears in both systems.

## Changes

- Added Core internal API configuration to `.env.example`.
- Fetches v6 eligible donations from `/api/internal/givbacks/donations` using the shared power-sync secret.
- Merges v5 and v6 eligible donations before aggregation.
- Dedupe uses parent recurring donation id when available, otherwise transaction hash and network.

## How to Test

1. Configure `GIVETH_V6_CORE_API_URL`, `POWER_SYNC_PASSWORD`, and `POWER_SYNC_PASSWORD_HEADER`.
2. Run `/calculate` with a May date range and existing GIVbacks parameters.
3. Confirm v6 donations appear in `allChains.givbacks` aggregation and duplicate tx/network rows are counted once.
4. Run `npm run build`.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Integrated a new Core API to expand eligible donation retrieval.
  * Added configurable header-based authentication for secure Core API access.
  * Implemented automatic deduplication across multiple data sources to remove duplicate donations.
  * Enhanced donation eligibility filtering with optional whitelist parameters.

* **Chores**
  * Updated example environment configuration with new Core API URL and Power Sync variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->