### PR TITLE
Release GIVbacks export fixes

### DIFF
--- a/src/givethIoService.ts
+++ b/src/givethIoService.ts
@@ -141,6 +141,19 @@ const donationDedupeKey = (donation: FormattedDonation): string => {
   return donationDedupeIdentifiers(donation).join('|')
 }
 
+const preserveParentRecurringDonationTxHash = (
+  target: FormattedDonation,
+  source: FormattedDonation,
+): void => {
+  if (
+    !target.parentRecurringDonationTxHash &&
+    source.parentRecurringDonationTxHash
+  ) {
+    target.parentRecurringDonationTxHash =
+      source.parentRecurringDonationTxHash
+  }
+}
+
 const mergeAndDedupeDonations = (
   donations: FormattedDonation[],
   additionalDonations: FormattedDonation[],
@@ -160,6 +173,11 @@ const mergeAndDedupeDonations = (
       const shouldPromoteIncomingDonation =
         Boolean(donation.parentRecurringDonationId) &&
         !existingDonation?.parentRecurringDonationId
+
+      if (existingDonation) {
+        preserveParentRecurringDonationTxHash(existingDonation, donation)
+        preserveParentRecurringDonationTxHash(donation, existingDonation)
+      }
 
       if (key && existingDonation && shouldPromoteIncomingDonation) {
         donationsByKey.delete(existingKey)

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,38 @@ const app = express();
 
 swaggerDocument.info.version = version
 
+const donationCsvFields = [
+  'amount',
+  'currency',
+  'createdAt',
+  'valueUsd',
+  'givbackFactor',
+  'projectRank',
+  'bottomRankInRound',
+  'givbacksRound',
+  'giverAddress',
+  'txHash',
+  'network',
+  'source',
+  'giverName',
+  'giverEmail',
+  'projectLink',
+  'niceTokens',
+  'info',
+  'isReferrerGivbackEligible',
+  'referrerWallet',
+  'referrer',
+  'referred',
+  'anonymous',
+  'parentRecurringDonationId',
+  'parentRecurringDonationTxHash',
+  'valueUsdAfterGivbackFactor',
+]
+
+const parseDonationCsv = (donations: FormattedDonation[]): string => {
+  return parse(donations, {fields: donationCsvFields})
+}
+
 // swaggerDocument.basePath = process.env.NODE_ENV === 'staging' ? '/staging' : '/'
 // const swaggerPrefix = process.env.NODE_ENV === 'staging' ? '/staging' : ''
 // https://stackoverflow.com/a/58052537/4650625
@@ -262,7 +294,7 @@ const getEligibleAndNonEligibleDonations = async (req: Request, res: Response, e
       })
 
     if (download === 'yes') {
-      const csv = parse(donations);
+      const csv = parseDonationCsv(donations);
       const fileName = `${eligible ? 'eligible-donations' : 'not-eligible-donations'}-${startDate}-${endDate}.csv`;
       res.setHeader('Content-disposition', "attachment; filename=" + fileName);
       res.setHeader('Content-type', 'application/json');
@@ -310,7 +342,7 @@ const getEligibleDonationsForNiceToken = async (req: Request, res: Response, eli
 
 
     if (download === 'yes') {
-      const csv = parse(donations);
+      const csv = parseDonationCsv(donations);
       const fileName = `${eligible ? 'eligible-donations-for-nice-tokens' : 'not-eligible-donations'}-${startDate}-${endDate}.csv`;
       res.setHeader('Content-disposition', "attachment; filename=" + fileName);
       res.setHeader('Content-type', 'application/json');
@@ -355,7 +387,7 @@ app.get(`/purpleList-donations-to-verifiedProjects`, async (req: Request, res: R
       })
 
     if (download === 'yes') {
-      const csv = parse(donations);
+      const csv = parseDonationCsv(donations);
       const fileName = `purpleList-donations-to-verifiedProjectz-${startDate}-${endDate}.csv`;
       res.setHeader('Content-disposition', "attachment; filename=" + fileName);
       res.setHeader('Content-type', 'application/json');


### PR DESCRIPTION
## Summary
- Preserve recurring parent transaction hashes when v5 and v6 donation rows are merged and de-duped.
- Keep donation CSV exports stable for empty result sets by using explicit CSV fields.
- Ensure `parentRecurringDonationTxHash` is present in both API responses and `download=yes` CSV exports when either duplicate source provides it.

## Test plan
- `pnpm build`
- Verified the reported production hash has `legacy_recurring_donation_tx_hash` populated in v6.
- Verified the release diff includes `parentRecurringDonationTxHash` in the CSV field list.


Made with [Cursor](https://cursor.com)