### PR TITLE
Require admin Basic Auth on all reporting endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,10 @@ PINATA_SECRET_API_KEY=
 GIV_ECONOMY_SUBGRAPH_URL=https://api.thegraph.com/subgraphs/name/giveth/giveth-economy-second-xdai
 
 REFERRAL_SHARE_PERCENTAGE=10
+
+# HTTP Basic Auth for the whole givback-calculation service. Every route
+# (all donation/report endpoints plus the /api-docs UI) requires these creds;
+# the service is internal tooling with no public consumers.
+# Leave ADMIN_EXPORT_PASSWORD unset to fail closed (all routes return 401).
+ADMIN_EXPORT_USERNAME=admin
+ADMIN_EXPORT_PASSWORD=

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "test:unit": "for f in givbacksRoundReport purpleListExport eligibilityThreshold mergeDedupe adminAuth; do ts-node --project ./tsconfig.json test/$f.test.ts || exit 1; done",
+    "test:unit": "for f in test/*.test.ts; do ts-node --project ./tsconfig.json \"$f\" || exit 1; done",
     "startOld": "nodemon src/index.js",
     "build": "tsc --project ./",
     "start": " ts-node-dev --project ./tsconfig.json --respawn ./src/index.ts"

--- a/src/adminAuth.ts
+++ b/src/adminAuth.ts
@@ -1,0 +1,66 @@
+import { Request, Response, NextFunction } from 'express'
+import { timingSafeEqual } from 'crypto'
+
+// Read at call time (not module load) so the value is correct regardless of
+// when dotenv runs, and so the guard is unit-testable.
+const getAdminCredentials = (): { username: string; password?: string } => ({
+  username: process.env.ADMIN_EXPORT_USERNAME || 'admin',
+  password: process.env.ADMIN_EXPORT_PASSWORD,
+})
+
+const secretsMatch = (provided: string, expected: string): boolean => {
+  const providedBuffer = Buffer.from(provided)
+  const expectedBuffer = Buffer.from(expected)
+  return (
+    providedBuffer.length === expectedBuffer.length &&
+    timingSafeEqual(providedBuffer, expectedBuffer)
+  )
+}
+
+const challenge = (res: Response, message: string) => {
+  res.setHeader('WWW-Authenticate', 'Basic realm="givbacks-admin"')
+  return res.status(401).send({ message })
+}
+
+/**
+ * HTTP Basic Auth guard for the GIVbacks admin/reporting endpoints.
+ * Many of these expose donor names/emails or operationally sensitive data, so
+ * they must not be public. Fails closed when ADMIN_EXPORT_PASSWORD is not
+ * configured.
+ *
+ * Applied to every route in src/index.ts, including the /api-docs UI. This is
+ * internal tooling with no public consumers (neither giveth-v6-core nor the
+ * frontend call it), so there are no anonymous endpoints. Any new endpoint must
+ * include this guard.
+ */
+export const adminExportAuth = (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  const credentials = getAdminCredentials()
+  if (!credentials.password) {
+    console.log('ADMIN_EXPORT_PASSWORD is not set; refusing admin export request')
+    return challenge(res, 'Admin export auth is not configured')
+  }
+
+  const header = req.headers.authorization || ''
+  const [scheme, encoded] = header.split(' ')
+  if (!scheme || scheme.toLowerCase() !== 'basic' || !encoded) {
+    return challenge(res, 'Authentication required')
+  }
+
+  const decoded = Buffer.from(encoded, 'base64').toString('utf8')
+  const separatorIndex = decoded.indexOf(':')
+  const username = separatorIndex === -1 ? decoded : decoded.slice(0, separatorIndex)
+  const password = separatorIndex === -1 ? '' : decoded.slice(separatorIndex + 1)
+
+  if (
+    username === credentials.username &&
+    secretsMatch(password, credentials.password)
+  ) {
+    return next()
+  }
+
+  return challenge(res, 'Invalid credentials')
+}

--- a/src/adminAuth.ts
+++ b/src/adminAuth.ts
@@ -55,8 +55,11 @@ export const adminExportAuth = (
   const username = separatorIndex === -1 ? decoded : decoded.slice(0, separatorIndex)
   const password = separatorIndex === -1 ? '' : decoded.slice(separatorIndex + 1)
 
+  // Use secretsMatch for the username too — keeps both compares
+  // constant-time (and length-safe) for symmetry. The username is not really
+  // a secret, but the same code path now treats both fields identically.
   if (
-    username === credentials.username &&
+    secretsMatch(username, credentials.username) &&
     secretsMatch(password, credentials.password)
   ) {
     return next()

--- a/src/adminAuth.ts
+++ b/src/adminAuth.ts
@@ -3,8 +3,8 @@ import { timingSafeEqual } from 'crypto'
 
 // Read at call time (not module load) so the value is correct regardless of
 // when dotenv runs, and so the guard is unit-testable.
-const getAdminCredentials = (): { username: string; password?: string } => ({
-  username: process.env.ADMIN_EXPORT_USERNAME || 'admin',
+const getAdminCredentials = (): { username?: string; password?: string } => ({
+  username: process.env.ADMIN_EXPORT_USERNAME,
   password: process.env.ADMIN_EXPORT_PASSWORD,
 })
 
@@ -25,8 +25,8 @@ const challenge = (res: Response, message: string) => {
 /**
  * HTTP Basic Auth guard for the GIVbacks admin/reporting endpoints.
  * Many of these expose donor names/emails or operationally sensitive data, so
- * they must not be public. Fails closed when ADMIN_EXPORT_PASSWORD is not
- * configured.
+ * they must not be public. Fails closed when ADMIN_EXPORT_USERNAME or
+ * ADMIN_EXPORT_PASSWORD is not configured.
  *
  * Applied to every route in src/index.ts, including the /api-docs UI. This is
  * internal tooling with no public consumers (neither giveth-v6-core nor the
@@ -39,8 +39,8 @@ export const adminExportAuth = (
   next: NextFunction,
 ) => {
   const credentials = getAdminCredentials()
-  if (!credentials.password) {
-    console.log('ADMIN_EXPORT_PASSWORD is not set; refusing admin export request')
+  if (!credentials.username || !credentials.password) {
+    console.log('ADMIN_EXPORT_USERNAME or ADMIN_EXPORT_PASSWORD is not set; refusing admin export request')
     return challenge(res, 'Admin export auth is not configured')
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,7 @@ import {
   getPurpleListExportRows,
   parsePurpleListCsv
 } from './purpleListExportService'
+import {adminExportAuth} from './adminAuth'
 
 import {getPurpleList} from './commonServices'
 import {get_dumpers_list} from "./subgraphService";
@@ -92,9 +93,10 @@ const parseDonationCsv = (donations: FormattedDonation[]): string => {
 // https://stackoverflow.com/a/58052537/4650625
 // app.use(`${swaggerPrefix}/api-docs`, swaggerUi.serve, swaggerUi.setup(swaggerDocument));
 
-app.use(`/api-docs`, swaggerUi.serve, swaggerUi.setup(swaggerDocument));
+app.use(`/api-docs`, adminExportAuth, swaggerUi.serve, swaggerUi.setup(swaggerDocument));
 
 app.get(`/calculate`,
+  adminExportAuth,
   async (req: Request, res: Response) => {
     try {
       console.log('start calculating')
@@ -368,25 +370,25 @@ const getEligibleDonationsForNiceToken = async (req: Request, res: Response, eli
   }
 }
 
-app.get(`/eligible-donations`, async (req: Request, res: Response) => {
+app.get(`/eligible-donations`, adminExportAuth, async (req: Request, res: Response) => {
   await getEligibleAndNonEligibleDonations(req, res, true)
 })
-app.get(`/getAllProjectsSortByRank`, async (req: Request, res: Response) => {
+app.get(`/getAllProjectsSortByRank`, adminExportAuth, async (req: Request, res: Response) => {
   const result = await getAllProjectsSortByRank()
   res.send(result)
 })
 
 
-app.get(`/eligible-donations-for-nice-token`, async (req: Request, res: Response) => {
+app.get(`/eligible-donations-for-nice-token`, adminExportAuth, async (req: Request, res: Response) => {
   await getEligibleDonationsForNiceToken(req, res)
 })
 
-app.get(`/not-eligible-donations`, async (req: Request, res: Response) => {
+app.get(`/not-eligible-donations`, adminExportAuth, async (req: Request, res: Response) => {
   await getEligibleAndNonEligibleDonations(req, res, false)
 })
 
 
-app.get(`/purpleList-donations-to-verifiedProjects`, async (req: Request, res: Response) => {
+app.get(`/purpleList-donations-to-verifiedProjects`, adminExportAuth, async (req: Request, res: Response) => {
   try {
     const {endDate, startDate, download} = req.query;
     const givethIoDonations = await getVerifiedPurpleListDonations(startDate as string, endDate as string);
@@ -449,7 +451,7 @@ app.get(`/purpleList-donations-to-verifiedProjects`, async (req: Request, res: R
 //     }
 // })
 
-app.get('/givPrice', async (req: Request, res: Response) => {
+app.get('/givPrice', adminExportAuth, async (req: Request, res: Response) => {
   try {
     let {blockNumber, txHash, network = 'xdai'} = req.query;
     let realBlockNumber = Number(blockNumber)
@@ -479,26 +481,28 @@ app.get('/givPrice', async (req: Request, res: Response) => {
   } catch (e: any) {
     console.log('/givPrice error', {
       error: e,
-      req,
+      url: req.originalUrl,
+      query: req.query,
     })
     res.status(400).send({errorMessage: e.message})
   }
 })
 
 
-app.get('/purpleList', async (req: Request, res: Response) => {
+app.get('/purpleList', adminExportAuth, async (req: Request, res: Response) => {
   try {
 
     res.json({purpleList: await getPurpleList()})
   } catch (e: any) {
     console.log('/purpleList error', {
       error: e,
-      req,
+      url: req.originalUrl,
+      query: req.query,
     })
     res.status(400).send({errorMessage: e.message})
   }
 })
-app.get('/givDumpers', async (req: Request, res: Response) => {
+app.get('/givDumpers', adminExportAuth, async (req: Request, res: Response) => {
   try {
     res.json(
       await get_dumpers_list({
@@ -510,13 +514,14 @@ app.get('/givDumpers', async (req: Request, res: Response) => {
   } catch (e: any) {
     console.log('/givDumpers error', {
       error: e,
-      req,
+      url: req.originalUrl,
+      query: req.query,
     })
     res.status(400).send({errorMessage: e.message})
   }
 })
 
-app.get('/token_distro_assign_histories', async (req: Request, res: Response) => {
+app.get('/token_distro_assign_histories', adminExportAuth, async (req: Request, res: Response) => {
   try {
     const {tokenDistroAddress, uniPoolAddress, rpcUrl} = req.query;
     res.json(
@@ -529,7 +534,8 @@ app.get('/token_distro_assign_histories', async (req: Request, res: Response) =>
   } catch (e: any) {
     console.log('/token_distro_assign_histories error', {
       error: e,
-      req,
+      url: req.originalUrl,
+      query: req.query,
     })
     res.status(400).send({errorMessage: e.message})
   }
@@ -537,6 +543,7 @@ app.get('/token_distro_assign_histories', async (req: Request, res: Response) =>
 
 
 app.get(`/calculate-updated`,
+  adminExportAuth,
   async (req: Request, res: Response) => {
     try {
       console.log('start calculating')
@@ -755,7 +762,8 @@ app.get(`/calculate-updated`,
     } catch (e: any) {
       console.log('/calculate-updated error', {
         error: e,
-        req,
+        url: req.originalUrl,
+        query: req.query,
       })
       res.status(400).send({
         message: e.message
@@ -768,7 +776,7 @@ app.get(`/calculate-updated`,
 // (GIV). Optional: givPrice (else computed at round end), minEligibleValueUsd,
 // givethCommunityProjectSlug, includeAllDonations=yes (eligible + ineligible),
 // download=yes (CSV). Returns the per-donation export + prize-pool summary.
-app.get(`/givbacks-round-report`, async (req: Request, res: Response) => {
+app.get(`/givbacks-round-report`, adminExportAuth, async (req: Request, res: Response) => {
   try {
     const {
       startDate, endDate, download, includeAllDonations,
@@ -842,7 +850,7 @@ app.get(`/givbacks-round-report`, async (req: Request, res: Response) => {
 
 // Issue #323: export the current GIVbacks purple list (addresses excluded from
 // receiving GIVbacks) separately from the donation export.
-app.get(`/givbacks-purple-list`, async (req: Request, res: Response) => {
+app.get(`/givbacks-purple-list`, adminExportAuth, async (req: Request, res: Response) => {
   try {
     const { download } = req.query;
     const rows = await getPurpleListExportRows()
@@ -862,14 +870,15 @@ app.get(`/givbacks-purple-list`, async (req: Request, res: Response) => {
   }
 })
 
-app.get(`/current-round`, async (req: Request, res: Response) => {
+app.get(`/current-round`, adminExportAuth, async (req: Request, res: Response) => {
     try {
       const result = await getCurrentGIVbacksRound()
       res.send(result)
     } catch (e: any) {
       console.log('/current-round error', {
         error: e,
-        req,
+        url: req.originalUrl,
+        query: req.query,
       })
       res.status(400).send({errorMessage: e.message})
     }

--- a/test/adminAuth.test.ts
+++ b/test/adminAuth.test.ts
@@ -101,6 +101,33 @@ check('calls next() on correct credentials', () => {
   assert.strictEqual(nexted, true)
 })
 
+// RFC 7617 compliance + edge-case hardening.
+
+check('401 on an empty password (basic admin:)', () => {
+  const { res, nexted } = run(basic('admin', ''))
+  assert.strictEqual(res.statusCode, 401)
+  assert.strictEqual(nexted, false)
+})
+
+check('401 on a payload with no colon (just a base64 username)', () => {
+  const encoded = Buffer.from('admin').toString('base64')
+  const { res, nexted } = run('Basic ' + encoded)
+  assert.strictEqual(res.statusCode, 401)
+  assert.strictEqual(nexted, false)
+})
+
+check('accepts case-insensitive Basic scheme (bAsIc) — RFC 7617', () => {
+  const encoded = Buffer.from('admin:s3cret').toString('base64')
+  const { nexted } = run('bAsIc ' + encoded)
+  assert.strictEqual(nexted, true)
+})
+
+check('401 on a longer-than-expected supplied password (no exception)', () => {
+  const { res, nexted } = run(basic('admin', 's3cretXXXXXXXX'))
+  assert.strictEqual(res.statusCode, 401)
+  assert.strictEqual(nexted, false)
+})
+
 console.log(`\nadminAuth.test.ts: ${passed} passed, ${failed} failed`)
 if (failed > 0) {
   process.exit(1)

--- a/test/adminAuth.test.ts
+++ b/test/adminAuth.test.ts
@@ -1,0 +1,107 @@
+import assert from 'assert'
+import type { Request, Response } from 'express'
+import { adminExportAuth } from '../src/adminAuth'
+
+// HTTP Basic Auth guard for the GIVbacks admin export endpoints (issue #323).
+// Run with: npx ts-node --project ./tsconfig.json test/adminAuth.test.ts
+
+let passed = 0
+let failed = 0
+const check = (label: string, fn: () => void) => {
+  try {
+    fn()
+    passed += 1
+  } catch (e: any) {
+    failed += 1
+    console.error(`FAIL: ${label}\n      ${e?.message ?? e}`)
+  }
+}
+
+interface MockRes {
+  statusCode: number
+  headers: Record<string, string>
+  body: unknown
+  setHeader: (k: string, v: string) => void
+  status: (c: number) => MockRes
+  send: (b: unknown) => MockRes
+}
+
+const mockRes = (): MockRes => {
+  const res = {
+    statusCode: 200,
+    headers: {} as Record<string, string>,
+    body: null as unknown,
+  } as MockRes
+  res.setHeader = (k, v) => {
+    res.headers[k] = v
+  }
+  res.status = c => {
+    res.statusCode = c
+    return res
+  }
+  res.send = b => {
+    res.body = b
+    return res
+  }
+  return res
+}
+
+const basic = (u: string, p: string) =>
+  'Basic ' + Buffer.from(`${u}:${p}`).toString('base64')
+
+const run = (authorization?: string) => {
+  const res = mockRes()
+  let nexted = false
+  const req = { headers: authorization ? { authorization } : {} } as Request
+  adminExportAuth(req, res as unknown as Response, () => {
+    nexted = true
+  })
+  return { res, nexted }
+}
+
+// Fails closed when the password env var is not configured.
+check('fails closed (401) when ADMIN_EXPORT_PASSWORD is unset', () => {
+  delete process.env.ADMIN_EXPORT_PASSWORD
+  const { res, nexted } = run(basic('admin', 'anything'))
+  assert.strictEqual(res.statusCode, 401)
+  assert.strictEqual(nexted, false)
+})
+
+// With a configured password:
+process.env.ADMIN_EXPORT_USERNAME = 'admin'
+process.env.ADMIN_EXPORT_PASSWORD = 's3cret'
+
+check('401 + challenge header when no Authorization header is present', () => {
+  const { res, nexted } = run()
+  assert.strictEqual(res.statusCode, 401)
+  assert.ok(res.headers['WWW-Authenticate'])
+  assert.strictEqual(nexted, false)
+})
+
+check('401 on a wrong password', () => {
+  const { res, nexted } = run(basic('admin', 'wrong'))
+  assert.strictEqual(res.statusCode, 401)
+  assert.strictEqual(nexted, false)
+})
+
+check('401 on a wrong username', () => {
+  const { res, nexted } = run(basic('attacker', 's3cret'))
+  assert.strictEqual(res.statusCode, 401)
+  assert.strictEqual(nexted, false)
+})
+
+check('401 on a non-Basic scheme', () => {
+  const { res, nexted } = run('Bearer s3cret')
+  assert.strictEqual(res.statusCode, 401)
+  assert.strictEqual(nexted, false)
+})
+
+check('calls next() on correct credentials', () => {
+  const { nexted } = run(basic('admin', 's3cret'))
+  assert.strictEqual(nexted, true)
+})
+
+console.log(`\nadminAuth.test.ts: ${passed} passed, ${failed} failed`)
+if (failed > 0) {
+  process.exit(1)
+}


### PR DESCRIPTION
## Summary

Adds HTTP Basic Auth (`adminExportAuth`) to **every** endpoint of the givback-calculation service, including the `/api-docs` UI — leaving no anonymous surface. Several endpoints expose donor names/emails.

- New `adminAuth.ts` middleware (+ unit test): reads creds at call time, uses `timingSafeEqual`, case-insensitive `Basic` scheme, and **fails closed** when `ADMIN_EXPORT_PASSWORD` is unset.
- `adminExportAuth` on all 15 routes incl. `/api-docs`, `/calculate(-updated)`, the donation/report endpoints, and the #323 `/givbacks-round-report` + `/givbacks-purple-list`.
- Redacts credentials from error logs (logs `url` + `query`, never the full `req`).
- Documents `ADMIN_EXPORT_USERNAME` / `ADMIN_EXPORT_PASSWORD` in `.env.example`.

## Stacked on #77

Base is `issue-323-givbacks-round-export` (**PR #77**), not `staging` — this PR contains **only** the auth layer on top of the #323 feature. **Merge after #77.**

Kept separate on purpose: we can decide independently whether the service needs app-level auth at all. If it's only reachable via VPN / internal network, this can wait or be dropped without blocking the #323 export feature.

## Test plan

- [x] `tsc --noEmit` clean; `adminAuth` unit tests (6) pass; all feature tests pass
- [x] Runtime: 401 without/with-invalid creds, pass-through with valid creds, `/api-docs` gated
- [ ] Decision: is app-level Basic Auth needed, or is network/VPN restriction sufficient?

🤖 Generated with [Claude Code](https://claude.com/claude-code)