### PR TITLE
Revert v5 GIVbacks API to March 2026 (commit 97024da)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,4 @@
 GIVETHIO_BASE_URL=https://mainnet.serve.giveth.io
-GIVETH_V6_CORE_API_URL=https://core.giveth.io
-POWER_SYNC_PASSWORD=
-POWER_SYNC_PASSWORD_HEADER=x-power-sync-password
 TRACE_BASE_URL=https://feathers.beta.giveth.io
 PURPLE_LIST=0x1ad91ee08f21be3de0ba2ba6918e714da6b45836,0x63ecc058D97ED7bAb75616B77C96734D0B823f87
 MAINNET_NODE_URL=https://mainnet.infura.io/v3/infuraApiKey

--- a/README.md
+++ b/README.md
@@ -1,5 +1,17 @@
 # Givback Calculation Service
 
+> **Reference version — March 2026 (v5-only).** This branch was reverted to
+> commit [`97024da`](https://github.com/Giveth/givback-calculation/commit/97024da2811513f18aec3231db506d0ec6e17257)
+> (`Merge pull request #71 — Ensure Cause donation data sent to GIVbacks is of
+> origin tx information`, 2025-11-12), which is the last commit before the
+> April/May 2026 changes that attempted to add v6 donations. All v6-related
+> work (PRs #72, #74, #75, #76) has been removed from this branch. The v6 work
+> remains available on the original feature branches
+> (`issue-264-v6-donations-calculate-api`, `issue-323-givbacks-round-export`)
+> as a starting point for the new combined v5/v6 GIVbacks system. See
+> [Giveth/giveth-dapps-v2#5569](https://github.com/Giveth/giveth-dapps-v2/issues/5569)
+> for context.
+
 ## 1. Project Overview
 
 ### Purpose

--- a/src/commonServices.ts
+++ b/src/commonServices.ts
@@ -8,10 +8,6 @@ const configPurpleList = process.env.PURPLE_LIST ? process.env.PURPLE_LIST.split
 const whiteListDonations = process.env.WHITELIST_DONATIONS ? process.env.WHITELIST_DONATIONS.split(',').map(address => address.toLowerCase()) : []
 const blackListDonations = process.env.BLACKLIST_DONATIONS ? process.env.BLACKLIST_DONATIONS.split(',').map(address => address.toLowerCase()) : []
 
-const normalizeAddressOrHash = (value?: string | null): string => {
-    return value ? value.toLowerCase() : ''
-}
-
 // Related to admin bro
 export const getPurpleList = async (): Promise<string[]> => {
     const query = gql`
@@ -29,15 +25,9 @@ export const getPurpleList = async (): Promise<string[]> => {
 export const filterDonationsWithPurpleList = async (donations: FormattedDonation[], disablePurpleList = false): Promise<FormattedDonation[]> => {
     const purpleList = disablePurpleList ? [] : await getPurpleList()
     return donations.filter(item => {
-        const giverAddress = normalizeAddressOrHash(item.giverAddress)
-        const txHash = normalizeAddressOrHash(item.txHash)
-        const isGiverPurpleList = purpleList.includes(giverAddress)
-        const isDonationWhitelisted = txHash
-            ? whiteListDonations.includes(txHash)
-            : false
-        const isDonationBlacklisted = txHash
-            ? blackListDonations.includes(txHash)
-            : false
+        const isGiverPurpleList = purpleList.includes(item.giverAddress.toLowerCase())
+        const isDonationWhitelisted = whiteListDonations.includes(item.txHash.toLowerCase())
+        const isDonationBlacklisted = blackListDonations.includes(item.txHash.toLowerCase())
         if (isDonationWhitelisted) {
             // It's important to check whitelist before purpleList
             return true
@@ -53,7 +43,7 @@ export const filterDonationsWithPurpleList = async (donations: FormattedDonation
 export const purpleListDonations = async (donations: FormattedDonation[], disablePurpleList = false): Promise<FormattedDonation[]> => {
     const purpleList = disablePurpleList ? [] : await getPurpleList()
     return donations.filter(item => {
-        return purpleList.includes(normalizeAddressOrHash(item.giverAddress))
+        return purpleList.includes(item.giverAddress.toLowerCase())
     })
 }
 

--- a/src/givethIoService.ts
+++ b/src/givethIoService.ts
@@ -14,7 +14,6 @@ const { isAddress } = require("ethers");
 require('dotenv').config()
 
 const { gql, request } = require('graphql-request');
-const axios = require('axios');
 const moment = require('moment')
 const _ = require('underscore')
 
@@ -31,13 +30,6 @@ import {
 } from "./utils";
 
 const givethiobaseurl = process.env.GIVETHIO_BASE_URL
-const givethV6CoreApiUrl = process.env.GIVETH_V6_CORE_API_URL
-const givethV6CoreApiPassword = process.env.POWER_SYNC_PASSWORD
-const givethV6CoreApiPasswordHeader =
-  process.env.POWER_SYNC_PASSWORD_HEADER || 'x-power-sync-password'
-const givethV6CoreApiTimeoutMs = Number(
-  process.env.GIVETH_V6_CORE_API_TIMEOUT_MS || 15000,
-)
 const xdaiNodeHttpUrl = process.env.XDAI_NODE_HTTP_URL
 const twoWeeksInMilliseconds = 1209600000
 console.log()
@@ -57,156 +49,6 @@ const isStellarDonationAndUserLoggedInWithEvmAddress = (donation: GivethIoDonati
 
 const donationGiverAddress = (donation: GivethIoDonation): string => {
   return isStellarDonationAndUserLoggedInWithEvmAddress(donation) ? donation.user.walletAddress : donation.fromWalletAddress
-}
-
-const getV6EligibleDonations = async (
-  params: {
-    beginDate: string,
-    endDate: string,
-    minEligibleValueUsd: number,
-    givethCommunityProjectSlug: string,
-    niceWhitelistTokens?: string[],
-    niceProjectSlugs?: string[],
-  }): Promise<FormattedDonation[]> => {
-  if (!givethV6CoreApiUrl || !givethV6CoreApiPassword) {
-    console.log('Skipping v6 Core donations: missing GIVETH_V6_CORE_API_URL or POWER_SYNC_PASSWORD')
-    return []
-  }
-
-  let response
-  try {
-    response = await axios.get(
-      `${givethV6CoreApiUrl.replace(/\/$/, '')}/api/internal/givbacks/donations`,
-      {
-        headers: {
-          [givethV6CoreApiPasswordHeader]: givethV6CoreApiPassword,
-        },
-        params: {
-          fromDate: params.beginDate,
-          toDate: params.endDate,
-          minEligibleValueUsd: params.minEligibleValueUsd,
-          givethCommunityProjectSlug: params.givethCommunityProjectSlug,
-          ...(params.niceWhitelistTokens?.length
-            ? { niceWhitelistTokens: params.niceWhitelistTokens.join(',') }
-            : {}),
-          ...(params.niceProjectSlugs?.length
-            ? { niceProjectSlugs: params.niceProjectSlugs.join(',') }
-            : {}),
-        },
-        timeout: givethV6CoreApiTimeoutMs,
-      },
-    )
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error)
-    console.log('Skipping v6 Core donations: request failed', message)
-    return []
-  }
-
-  const rows = response?.data?.data
-  if (!Array.isArray(rows)) {
-    return []
-  }
-
-  return rows.map((row: FormattedDonation) => ({
-    ...row,
-    giverName: row.giverName || '',
-    giverEmail: row.giverEmail || '',
-    isReferrerGivbackEligible: Boolean(row.isReferrerGivbackEligible),
-    referrerWallet: row.referrerWallet || undefined,
-  }))
-}
-
-const normalizeDedupeValue = (value?: string | number): string => {
-  return String(value || '').trim().toLowerCase()
-}
-
-const donationDedupeIdentifiers = (donation: FormattedDonation): string[] => {
-  const identifiers: string[] = []
-  if (donation.parentRecurringDonationId) {
-    identifiers.push(
-      `recurring:${normalizeDedupeValue(donation.parentRecurringDonationId)}`,
-    )
-  }
-
-  const txHash = normalizeDedupeValue(donation.txHash)
-  const network = normalizeDedupeValue(donation.network)
-  if (txHash && network) {
-    identifiers.push(`tx:${network}:${txHash}`)
-  }
-
-  return identifiers
-}
-
-const donationDedupeKey = (donation: FormattedDonation): string => {
-  return donationDedupeIdentifiers(donation).join('|')
-}
-
-const preserveParentRecurringDonationTxHash = (
-  target: FormattedDonation,
-  source: FormattedDonation,
-): void => {
-  if (
-    !target.parentRecurringDonationTxHash &&
-    source.parentRecurringDonationTxHash
-  ) {
-    target.parentRecurringDonationTxHash =
-      source.parentRecurringDonationTxHash
-  }
-}
-
-const mergeAndDedupeDonations = (
-  donations: FormattedDonation[],
-  additionalDonations: FormattedDonation[],
-): FormattedDonation[] => {
-  const donationsByKey = new Map<string, FormattedDonation>()
-  const canonicalKeyByIdentifier = new Map<string, string>()
-
-  for (const donation of donations.concat(additionalDonations)) {
-    const key = donationDedupeKey(donation)
-    const identifiers = donationDedupeIdentifiers(donation)
-    const existingKey = identifiers
-      .map(identifier => canonicalKeyByIdentifier.get(identifier))
-      .find(Boolean)
-
-    if (existingKey) {
-      const existingDonation = donationsByKey.get(existingKey)
-      const shouldPromoteIncomingDonation =
-        Boolean(donation.parentRecurringDonationId) &&
-        !existingDonation?.parentRecurringDonationId
-
-      if (existingDonation) {
-        preserveParentRecurringDonationTxHash(existingDonation, donation)
-        preserveParentRecurringDonationTxHash(donation, existingDonation)
-      }
-
-      if (key && existingDonation && shouldPromoteIncomingDonation) {
-        donationsByKey.delete(existingKey)
-        donationsByKey.set(key, donation)
-        const promotedIdentifiers = [
-          ...donationDedupeIdentifiers(existingDonation),
-          ...identifiers,
-        ]
-        promotedIdentifiers.forEach(identifier =>
-          canonicalKeyByIdentifier.set(identifier, key),
-        )
-        continue
-      }
-
-      identifiers.forEach(identifier =>
-        canonicalKeyByIdentifier.set(identifier, existingKey),
-      )
-      continue
-    }
-
-    if (key && !donationsByKey.has(key)) {
-      donationsByKey.set(key, donation)
-      identifiers.forEach(identifier =>
-        canonicalKeyByIdentifier.set(identifier, key),
-      )
-    }
-  }
-
-  return Array.from(donationsByKey.values())
 }
 
 /**
@@ -464,14 +306,8 @@ export const getEligibleDonations = async (
     const notEligibleDonations = (
       await purpleListDonations(formattedDonationsToVerifiedProjects)
     ).concat(formattedDonationsToNotVerifiedProjects)
-    const eligibleDonationKeys = new Set(
-      eligibleDonations.flatMap(donation => donationDedupeIdentifiers(donation)),
-    )
-    const commonDonations = notEligibleDonations.filter(donation =>
-      donationDedupeIdentifiers(donation).some(key =>
-        eligibleDonationKeys.has(key),
-      ),
-    )
+    const eligibleTxHashes = new Set(eligibleDonations.map(donation => donation.txHash));
+    const commonDonations = notEligibleDonations.filter(donation => eligibleTxHashes.has(donation.txHash));
 
 
     console.log('donations length', {
@@ -481,20 +317,7 @@ export const getEligibleDonations = async (
       // It should be zero
       commonDonations: commonDonations.length
     })
-    if (!eligible) {
-      return notEligibleDonations
-    }
-
-    const v6EligibleDonations = await getV6EligibleDonations({
-      beginDate,
-      endDate,
-      niceWhitelistTokens,
-      niceProjectSlugs,
-      minEligibleValueUsd,
-      givethCommunityProjectSlug,
-    })
-
-    return mergeAndDedupeDonations(eligibleDonations, v6EligibleDonations)
+    return eligible ? eligibleDonations : notEligibleDonations
 
 
   } catch (e) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,38 +45,6 @@ const app = express();
 
 swaggerDocument.info.version = version
 
-const donationCsvFields = [
-  'amount',
-  'currency',
-  'createdAt',
-  'valueUsd',
-  'givbackFactor',
-  'projectRank',
-  'bottomRankInRound',
-  'givbacksRound',
-  'giverAddress',
-  'txHash',
-  'network',
-  'source',
-  'giverName',
-  'giverEmail',
-  'projectLink',
-  'niceTokens',
-  'info',
-  'isReferrerGivbackEligible',
-  'referrerWallet',
-  'referrer',
-  'referred',
-  'anonymous',
-  'parentRecurringDonationId',
-  'parentRecurringDonationTxHash',
-  'valueUsdAfterGivbackFactor',
-]
-
-const parseDonationCsv = (donations: FormattedDonation[]): string => {
-  return parse(donations, {fields: donationCsvFields})
-}
-
 // swaggerDocument.basePath = process.env.NODE_ENV === 'staging' ? '/staging' : '/'
 // const swaggerPrefix = process.env.NODE_ENV === 'staging' ? '/staging' : ''
 // https://stackoverflow.com/a/58052537/4650625
@@ -294,7 +262,7 @@ const getEligibleAndNonEligibleDonations = async (req: Request, res: Response, e
       })
 
     if (download === 'yes') {
-      const csv = parseDonationCsv(donations);
+      const csv = parse(donations);
       const fileName = `${eligible ? 'eligible-donations' : 'not-eligible-donations'}-${startDate}-${endDate}.csv`;
       res.setHeader('Content-disposition', "attachment; filename=" + fileName);
       res.setHeader('Content-type', 'application/json');
@@ -342,7 +310,7 @@ const getEligibleDonationsForNiceToken = async (req: Request, res: Response, eli
 
 
     if (download === 'yes') {
-      const csv = parseDonationCsv(donations);
+      const csv = parse(donations);
       const fileName = `${eligible ? 'eligible-donations-for-nice-tokens' : 'not-eligible-donations'}-${startDate}-${endDate}.csv`;
       res.setHeader('Content-disposition', "attachment; filename=" + fileName);
       res.setHeader('Content-type', 'application/json');
@@ -387,7 +355,7 @@ app.get(`/purpleList-donations-to-verifiedProjects`, async (req: Request, res: R
       })
 
     if (download === 'yes') {
-      const csv = parseDonationCsv(donations);
+      const csv = parse(donations);
       const fileName = `purpleList-donations-to-verifiedProjectz-${startDate}-${endDate}.csv`;
       res.setHeader('Content-disposition', "attachment; filename=" + fileName);
       res.setHeader('Content-type', 'application/json');


### PR DESCRIPTION
## Summary

Resets the v5 GIVbacks API on **`master`** (production) to the state at commit [`97024da`](https://github.com/Giveth/givback-calculation/commit/97024da2811513f18aec3231db506d0ec6e17257) — the last commit before the April/May 2026 changes that tried to add v6 donations and made the service unusable for Ashley's reporting workflow. Retargeted to `master` instead of `staging` because there are live issues on staging and the revert needs to land on production.

The diff against `master` undoes:

- **6bdb4c0** Include v6 donations in GIVbacks calculation (2026-05-01)
- **f933a68** Fix v6 donation dedupe fallback (2026-05-04)
- **43ba985** Refine v6 donation dedupe (2026-05-04)
- **aeb587c** Merge PR #72 `issue-264-v6-donations-calculate-api` (2026-05-05)
- **a1d0a64** Fix null donation hash filtering (2026-05-05)
- **f2df258** Fix empty donation CSV downloads (2026-05-05)
- **ee5be9b** Preserve recurring parent hashes in donation exports (2026-05-11)

A banner is added to `README.md` documenting the restored commit so the team can trace the reference point later.

The v6 work is **not lost** — it's still on the original feature branches (`issue-264-v6-donations-calculate-api`, `issue-323-givbacks-round-export`, `admin-export-auth`, `backup/admin-export-auth-v1`, `backup/issue-323-pre-auth-split`) and will be the starting point for the new combined v5/v6 GIVbacks system being built separately.

Closes [Giveth/giveth-dapps-v2#5569](https://github.com/Giveth/giveth-dapps-v2/issues/5569).

## Test plan

- [ ] Confirm production deployment serves the v5-only calculation flow after merge
- [ ] Ashley runs her existing GIVbacks reporting workflow against the reverted API and verifies it behaves as it did in March 2026
- [ ] CI / smoke tests pass on the reverted tree
- [ ] Verify v6 work remains intact on the preserved feature branches
- [ ] Decide whether `staging` should also be reverted (it still has issue #323 / PR #77 on top of v6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)