### PR TITLE
Prefer v6 Core over v5 mirror in /givbacks-round-report dedup (#323)

### DIFF
--- a/src/givethIoService.ts
+++ b/src/givethIoService.ts
@@ -246,10 +246,19 @@ export const getGivbacksRoundDonations = async (
     v5IneligibleP,
   ])
 
+  // v6 Core is the source of truth for donations made via the v6 stack. The
+  // legacy data-sync cron mirrors most v6 donations back into v5 (impact-graph)
+  // for backward compatibility, so a single donation typically appears in BOTH
+  // sources. We pass v6 FIRST to mergeAndDedupeDonations so the v6 row wins
+  // on a collision — that way the export's `source` column honestly reflects
+  // where the donation originated, instead of always showing 'giveth.io'
+  // because v5 happens to be loaded earlier. Scoped to /givbacks-round-report
+  // only; the legacy /calculate-updated path keeps the v5-first behavior its
+  // consumers already expect.
   const v6Eligible = v6Donations.filter(
     donation => donation.isDonationGivbacksEligible !== false,
   )
-  const eligibleDonations = mergeAndDedupeDonations(v5Eligible, v6Eligible)
+  const eligibleDonations = mergeAndDedupeDonations(v6Eligible, v5Eligible)
     .map(donation => ({ ...donation, isDonationGivbacksEligible: true }))
 
   if (!includeIneligible) {
@@ -259,9 +268,10 @@ export const getGivbacksRoundDonations = async (
   const v6Ineligible = v6Donations.filter(
     donation => donation.isDonationGivbacksEligible === false,
   )
+  // Same v6-first ordering for the ineligible bucket.
   const ineligibleDonations = [
-    ...v5Ineligible,
     ...v6Ineligible,
+    ...v5Ineligible,
   ].map(donation => ({ ...donation, isDonationGivbacksEligible: false }))
 
   // Eligible rows are passed first so they win on any tx/recurring key collision


### PR DESCRIPTION
## Summary

One-line behavior change for the new GIVbacks round export (issue [#323](https://github.com/Giveth/giveth-v6-core/issues/323)):

- `getGivbacksRoundDonations` now passes **v6 first** to `mergeAndDedupeDonations`, so v6 wins on collision instead of v5.

## Why

The legacy data-sync cron mirrors most v6 donations back into v5 (impact-graph) for backward compat, so the same donation typically appears in **both** sources. With the previous order (v5 first), every mirrored donation showed up in the round-export CSV as `source=v5`, even when it originated in v6. Confirmed today by hitting staging: `/eligible-donations` returns 3 rows for a window where v6 has 2 of those 3, but all 3 show as `source=giveth.io` because v5 mirrors v6 and wins the merge.

Counts are unaffected — the dedup logic is unchanged, only the precedence on key collision. The `source` column on the CSV now honestly reflects where the donation **originated**.

## Scope

- Only `getGivbacksRoundDonations` (which serves `/givbacks-round-report`).
- Legacy paths (`/eligible-donations`, `/calculate-updated`) keep their v5-first behavior — they go through `getEligibleDonations` directly, which I did not touch. Their existing consumers expect the v5 label and we don't want to surprise them.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] All 31 unit tests pass (`npm run test:unit`)
- [x] `mergeDedupe.test.ts` still passes — first-arg-wins is a stable contract of `mergeAndDedupeDonations`; only the call sites' argument order changed
- [ ] After merge to `staging`, hit `https://givback.develop.giveth.io/givbacks-round-report?...&includeAllDonations=yes` and confirm donations that exist in both v5 and v6 now show `source: "v6"` in the CSV

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced donation data deduplication and merging logic to ensure consistent and accurate results when processing donations from multiple sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->