### PR TITLE
Cross-check v5 donations against v6 Core purple list (#323)

### DIFF
--- a/src/givethIoService.ts
+++ b/src/givethIoService.ts
@@ -23,6 +23,7 @@ import {
   filterDonationsWithPurpleList, groupDonationsByParentRecurringId,
   purpleListDonations
 } from './commonServices';
+import { getPurpleListAddressSet } from './purpleListExportService';
 import {
   calculateReferralReward,
   calculateReferralRewardFromRemainingAmount,
@@ -240,11 +241,40 @@ export const getGivbacksRoundDonations = async (
       })
     : Promise.resolve<FormattedDonation[]>([])
 
-  const [v5Eligible, v6Donations, v5Ineligible] = await Promise.all([
-    v5EligibleP,
-    v6DonationsP,
-    v5IneligibleP,
-  ])
+  // Issue #323: v5's filterDonationsWithPurpleList only knows about
+  // impact-graph's purple list. A donor added directly to v6 Core's purple
+  // list (via project address or GIVbacks-eligibility-form) won't be
+  // recognized by v5's filter, so their v5 (or v5-mirror) donations sneak
+  // through as eligible. Fetch v6's purple list here so we can cross-check
+  // every v5 row against it below. Soft-fails to an empty set when v6 Core
+  // is unreachable.
+  const v6PurpleListP = getPurpleListAddressSet()
+
+  const [v5Eligible, v6Donations, v5Ineligible, v6PurpleAddresses] =
+    await Promise.all([
+      v5EligibleP,
+      v6DonationsP,
+      v5IneligibleP,
+      v6PurpleListP,
+    ])
+
+  const isOnV6PurpleList = (donation: FormattedDonation): boolean => {
+    const giver = (donation.giverAddress || '').trim().toLowerCase()
+    return giver.length > 0 && v6PurpleAddresses.has(giver)
+  }
+
+  // Move v5 eligibles whose donor is on v6's purple list into the ineligible
+  // bucket — they fail Lauren's added eligibility rule even though v5's own
+  // filter let them through.
+  const v5EligibleAfterV6Purple: FormattedDonation[] = []
+  const v5PurpleListedDonations: FormattedDonation[] = []
+  for (const donation of v5Eligible) {
+    if (isOnV6PurpleList(donation)) {
+      v5PurpleListedDonations.push(donation)
+    } else {
+      v5EligibleAfterV6Purple.push(donation)
+    }
+  }
 
   // v6 Core is the source of truth for donations made via the v6 stack. The
   // legacy data-sync cron mirrors most v6 donations back into v5 (impact-graph)
@@ -258,8 +288,10 @@ export const getGivbacksRoundDonations = async (
   const v6Eligible = v6Donations.filter(
     donation => donation.isDonationGivbacksEligible !== false,
   )
-  const eligibleDonations = mergeAndDedupeDonations(v6Eligible, v5Eligible)
-    .map(donation => ({ ...donation, isDonationGivbacksEligible: true }))
+  const eligibleDonations = mergeAndDedupeDonations(
+    v6Eligible,
+    v5EligibleAfterV6Purple,
+  ).map(donation => ({ ...donation, isDonationGivbacksEligible: true }))
 
   if (!includeIneligible) {
     return eligibleDonations
@@ -268,10 +300,13 @@ export const getGivbacksRoundDonations = async (
   const v6Ineligible = v6Donations.filter(
     donation => donation.isDonationGivbacksEligible === false,
   )
-  // Same v6-first ordering for the ineligible bucket.
+  // Same v6-first ordering for the ineligible bucket. v5 donations whose
+  // donor sits on v6's purple list are appended here too so the all-donations
+  // export still surfaces them (tagged ineligible).
   const ineligibleDonations = [
     ...v6Ineligible,
     ...v5Ineligible,
+    ...v5PurpleListedDonations,
   ].map(donation => ({ ...donation, isDonationGivbacksEligible: false }))
 
   // Eligible rows are passed first so they win on any tx/recurring key collision

--- a/src/purpleListExportService.ts
+++ b/src/purpleListExportService.ts
@@ -58,3 +58,30 @@ export const getPurpleListExportRows = async (): Promise<PurpleListExportRow[]> 
 
 export const parsePurpleListCsv = (rows: PurpleListExportRow[]): string =>
   parse(rows, { fields: PURPLE_LIST_CSV_FIELDS })
+
+/**
+ * Returns a lowercase Set of addresses on v6 Core's purple list. The round
+ * export (issue #323) uses this to filter v5 donations whose donor is on v6's
+ * purple list but NOT on v5's own (impact-graph) purple list — e.g. a donor
+ * added to v6 directly without an impact-graph counterpart.
+ *
+ * Fails gracefully: returns an empty set on any error (missing config,
+ * v6 Core unreachable, endpoint not yet deployed) so the export still
+ * works at v5-only-filtering quality until v6 Core is available.
+ */
+export const getPurpleListAddressSet = async (): Promise<Set<string>> => {
+  try {
+    const rows = await getPurpleListExportRows()
+    const addresses = rows
+      .map(row => (row.address || '').trim().toLowerCase())
+      .filter(address => address.length > 0)
+    return new Set(addresses)
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : String(error)
+    console.warn(
+      `Could not fetch v6 Core purple list; v5 donations will NOT be cross-checked against it. ${message}`,
+    )
+    return new Set()
+  }
+}

--- a/test/purpleListExport.test.ts
+++ b/test/purpleListExport.test.ts
@@ -1,6 +1,6 @@
 import assert from 'assert'
 import { PurpleListExportRow } from '../src/types/general'
-import { parsePurpleListCsv } from '../src/purpleListExportService'
+import { parsePurpleListCsv, getPurpleListAddressSet } from '../src/purpleListExportService'
 
 // AC-mapped unit test for the GIVbacks purple-list CSV export (issue #323).
 // Run with: npx ts-node --project ./tsconfig.json test/purpleListExport.test.ts
@@ -49,6 +49,26 @@ check('AC#20/#21 rows carry recipient + eligibility-form sources', () => {
   assert.ok(csv.includes('givbacksEligibilityForm'))
   assert.ok(csv.includes('0xRecipient'))
   assert.ok(csv.includes('GABCSTELLAR'))
+})
+
+// AC #18 — v6 purple list fetch must soft-fail to empty when v6 Core is
+// unreachable / missing env config, so v5-only filtering still works.
+// Runs without GIVETH_V6_CORE_API_URL / POWER_SYNC_PASSWORD set, which makes
+// getPurpleListExportRows() throw the "missing config" error, which
+// getPurpleListAddressSet() must catch.
+check('AC#18 v6 purple-list fetch soft-fails to empty Set on error', async () => {
+  const originalUrl = process.env.GIVETH_V6_CORE_API_URL
+  const originalPwd = process.env.POWER_SYNC_PASSWORD
+  delete process.env.GIVETH_V6_CORE_API_URL
+  delete process.env.POWER_SYNC_PASSWORD
+  try {
+    const result = await getPurpleListAddressSet()
+    assert.ok(result instanceof Set, 'should return a Set')
+    assert.strictEqual(result.size, 0, 'should be empty on error')
+  } finally {
+    if (originalUrl !== undefined) process.env.GIVETH_V6_CORE_API_URL = originalUrl
+    if (originalPwd !== undefined) process.env.POWER_SYNC_PASSWORD = originalPwd
+  }
 })
 
 console.log(`\npurpleListExport.test.ts: ${passed} passed, ${failed} failed`)


### PR DESCRIPTION
## Problem

QA found a v5 donation that survives `/givbacks-round-report` as eligible even though its donor is on the GIVbacks purple list per the v6 admin checker.

- Donor: `0xd5db3f8b0a236176587460dc85f0fc5705d78477`
- Donation: `0xf02b9e9e04e92899382a7558138d16c470882f2ade4ad5dcff8471c538ae9a1e` (v5 / impact-graph)
- `isDonationGivbacksEligible: true` in the export

Verified against the live data: impact-graph's `getPurpleList` returns 15,961 addresses but does **not** contain this donor. The donor IS on v6 Core's purple list (added via `ProjectAddress` / `GivbacksEligibilityForm`). v5 doesn't sync from v6.

So `filterDonationsWithPurpleList` (v5-side) lets the donation through. The v6 path doesn't see the donation (it's v5-native). The two purple lists are independent → the donation slips through.

## Fix

The round-export orchestrator now fetches v6's purple list and applies it as a second filter to v5 donations:

- New `getPurpleListAddressSet()` in `purpleListExportService.ts` — returns a lowercase `Set<string>` of every v6 purple-list address. Soft-fails to an empty Set on any error (missing config, v6 unreachable, endpoint not yet deployed).
- `getGivbacksRoundDonations` runs that fetch in parallel with the v5/v6 donation fetches and partitions v5 eligibles into "still eligible" vs "v6 purple-listed".
- Purple-listed v5 rows are tagged `isDonationGivbacksEligible: false` and surfaced in the all-donations export so the operator can audit them.

## Scope

Only `/givbacks-round-report`. The legacy `/eligible-donations` and `/calculate-updated` paths still use v5-only filtering — their consumers expect that behavior.

## Deployment dependency

The fetch only succeeds once v6 Core's `/api/internal/givbacks/purple-list` endpoint is reachable. That endpoint is in [Giveth/giveth-v6-core#334](https://github.com/Giveth/giveth-v6-core/pull/334), which is on v6-core `main` but **not yet on `staging`** (`9da4679` vs `d5f4bee`). Until v6-core staging picks up #334, the fetch will 404 — the soft-fail returns an empty Set and behavior stays at today's v5-only filtering with a `console.warn`. **No regression.** Once v6-core staging promotes `main`, the filter activates automatically.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] All 32 unit tests pass (added one for the soft-fail path)
- [ ] After v6-core staging deploys #334 and this PR is merged, retry the donation above on `https://givback.develop.giveth.io/givbacks-round-report?startDate=2026/05/01-00:00:00&endDate=2026/06/06-00:00:00&maxPrizePool=1500000&includeAllDonations=yes` — should now appear with `isDonationGivbacksEligible: false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved cross-version purple-list mismatch to ensure accurate donation eligibility categorization across versions.
  * Donations are now properly categorized based on purple-list status with improved merging and deduplication logic.
  * Enhanced error handling for missing configuration to allow system continuity while logging warnings.

* **Tests**
  * Added test coverage for error handling when configuration is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->