### PR TITLE
Source round-report GIV price from v6 Core instead of CryptoCompare (#323)

### DIFF
--- a/src/givethIoService.ts
+++ b/src/givethIoService.ts
@@ -203,6 +203,39 @@ const getV6EligibleDonations = async (
 }
 
 /**
+ * Fetches the current GIV/USD price from v6 Core's internal endpoint, which
+ * proxies BlockchainService.getTokenPrice (the same CoinGecko-backed source
+ * that sets donation.priceUsd). Used by the GIVbacks round export (issue #323)
+ * instead of CryptoCompare. Reuses the same auth/connectivity as the donations
+ * feed — no new env var.
+ *
+ * Returns undefined when v6 Core is not configured (so the caller can surface
+ * the &givPrice= override guidance). Throws on a configured-but-failing call or
+ * an invalid price.
+ */
+export const getGivPriceFromV6Core = async (): Promise<number | undefined> => {
+  if (!givethV6CoreApiUrl || !givethV6CoreApiPassword) {
+    return undefined
+  }
+
+  const response = await axios.get(
+    `${givethV6CoreApiUrl.replace(/\/$/, '')}/api/internal/givbacks/giv-price`,
+    {
+      headers: {
+        [givethV6CoreApiPasswordHeader]: givethV6CoreApiPassword,
+      },
+      timeout: givethV6CoreApiTimeoutMs,
+    },
+  )
+
+  const priceUsd = Number(response?.data?.data?.priceUsd)
+  if (!Number.isFinite(priceUsd) || priceUsd <= 0) {
+    throw new Error('v6 Core returned an invalid GIV price')
+  }
+  return priceUsd
+}
+
+/**
  * GIVbacks round export (issue #323) data source: returns every donation in the
  * window from BOTH v5 (giveth.io) and v6 Core, each tagged with
  * `isDonationGivbacksEligible`. When `includeIneligible` is false only eligible

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,7 @@ import {
   getDonationsReport,
   getEligibleDonations,
   getGivbacksRoundDonations,
+  getGivPriceFromV6Core,
   getVerifiedPurpleListDonations
 } from './givethIoService'
 
@@ -807,46 +808,34 @@ app.get(`/givbacks-round-report`, async (req: Request, res: Response) => {
       throw new Error(`startDate and endDate must be UTC ${dateFormat}`)
     }
 
-    // GIV price at the end of the round (issue #323). An explicit override may be
-    // passed for reproducing historical numbers without on-chain lookups.
+    // GIV price for the round (issue #323). An explicit &givPrice= override is
+    // used as-is — it's the path for reproducing a historical round at its true
+    // round-end price. When omitted, we fetch the CURRENT GIV/USD price from v6
+    // Core's internal endpoint (the same CoinGecko-backed source that prices
+    // donations). Run right after a round closes, current ≈ round-end price.
     let givPrice = Number(req.query.givPrice)
     if (!Number.isFinite(givPrice) || givPrice <= 0) {
       try {
-        const endDateTimestamp = endMoment.unix()
-        const priceBlock = await getBlockByTimestamp(endDateTimestamp, 1)
-        // getBlockByTimestamp swallows errors and returns 0. A 0 block is
-        // falsy, so getEthGivPriceInMainnet(0) would silently query the
-        // CURRENT pool instead of the round-end block — producing a plausible
-        // but wrong price that escapes the givPrice<=0 guard below and would
-        // scale the entire round's GIVbacks distribution. Fail loudly instead.
-        if (!priceBlock || priceBlock <= 0) {
-          throw new Error(
-            'Could not resolve a mainnet block for the round-end timestamp',
-          )
+        const fetched = await getGivPriceFromV6Core()
+        if (fetched === undefined) {
+          throw new Error('v6 Core price source is not configured')
         }
-        const givPriceInETH = await getEthGivPriceInMainnet(priceBlock)
-        const ethPrice = await getEthPriceTimeStamp(endDateTimestamp)
-        givPrice = givPriceInETH * ethPrice
-        console.log('/givbacks-round-report computed GIV price', {
-          endDateTimestamp, priceBlock, givPriceInETH, ethPrice, givPrice
+        givPrice = fetched
+        console.log('/givbacks-round-report fetched GIV price from v6 Core', {
+          givPrice,
         })
       } catch (priceError: any) {
-        // Auto price computation hits external services (findblock, the GIV
-        // subgraph, and a CryptoCompare ETH/USD lookup). When one of those
-        // fails (e.g. CryptoCompare 401 without an API key) the raw error is
-        // opaque ("Request failed with status code 401"). Surface an
-        // actionable message and the documented override instead.
-        console.log('/givbacks-round-report price computation failed', {
+        console.log('/givbacks-round-report price fetch failed', {
           error: priceError?.message ?? priceError,
         })
         throw new Error(
-          `Could not auto-compute the round-end GIV price (${priceError?.message ?? priceError}). ` +
+          `Could not fetch the round GIV price (${priceError?.message ?? priceError}). ` +
             'Pass an explicit &givPrice=<USD per GIV> to override.',
         )
       }
       if (!Number.isFinite(givPrice) || givPrice <= 0) {
         throw new Error(
-          'Auto-computed GIV price was invalid. Pass an explicit &givPrice=<USD per GIV> to override.',
+          'Fetched GIV price was invalid. Pass an explicit &givPrice=<USD per GIV> to override.',
         )
       }
     }


### PR DESCRIPTION
## Why

The round export's GIV-price auto-computation depended on CryptoCompare (now 401 for keyless requests). This sources the price from a Giveth service we control instead.

## What

When `&givPrice=` is omitted, `/givbacks-round-report` now fetches the GIV/USD price from v6 Core's new **`GET /api/internal/givbacks/giv-price`** ([giveth-v6-core#357](https://github.com/Giveth/giveth-v6-core/pull/357)) — which proxies `BlockchainService.getTokenPrice`, the same CoinGecko-backed source that prices donations.

- New `getGivPriceFromV6Core()` mirrors the existing `getV6EligibleDonations` client (same `GIVETH_V6_CORE_API_URL` / `POWER_SYNC_PASSWORD` / header / timeout). **No new env var.**
- The explicit `&givPrice=` override is unchanged — still the path for reproducing a historical round at its true round-end price.
- On fetch failure → the actionable *"pass &givPrice="* message.
- `getBlockByTimestamp` / `getEthGivPriceInMainnet` / `getEthPriceTimeStamp` are no longer used by the round report (still used by `/calculate-updated` and `/givPrice`, untouched).

## Stacking
Base is [`fix/323-round-report-price-401-and-min-usd-default`](https://github.com/Giveth/givback-calculation/pull/83) (the min-USD `$4` default + error scaffolding). When #83 merges to `staging`, GitHub will offer to retarget this to `staging`.

## Deploy ordering
Deploy **v6-core#357 first**. If this ships before it, the fetch 404s and the operator gets the `&givPrice=` fallback message — no silent bad price.

## Test plan
- [x] `tsc --noEmit` clean; 37 unit tests pass
- [x] **Full chain verified locally** (givback-calc → v6 Core → blockchain-integration-service → CoinGecko):
  - no `givPrice` → **200**, `givPrice: 0.00053712` fetched from v6 Core (log: *"fetched GIV price from v6 Core"*)
  - explicit `givPrice=0.02` → used as-is, **no** v6 fetch (override short-circuits)
  - min-USD default holds: 0 eligible rows under \$4

🤖 Generated with [Claude Code](https://claude.com/claude-code)